### PR TITLE
FIX: arguments occasionally getting mangled in calls to `default`

### DIFF
--- a/ksonnet-gen/ksonnet/ast.go
+++ b/ksonnet-gen/ksonnet/ast.go
@@ -185,8 +185,7 @@ func makeConstructor(parent *namespace, model k8s.Model) *constructor {
 		var rhs string
 		if property.Type != nil && (*property.Type == "array") {
 			rhs = fmt.Sprintf(
-				"if std.type(%s) == \"array\" then {%s: %s} else {%s: [%s]}", requiredParam.id,
-				requiredParam.id,
+				"if std.type(%s) == \"array\" then %s else [%s]",
 				requiredParam.id,
 				requiredParam.id,
 				requiredParam.id)

--- a/ksonnet.beta.1/apps.v1beta1.libsonnet
+++ b/ksonnet.beta.1/apps.v1beta1.libsonnet
@@ -19,7 +19,7 @@
         namespaced: namespaced,
         shortNames: [],
         singularName: singularName,
-        verbs: if std.type(verbs) == "array" then {verbs: verbs} else {verbs: [verbs]},
+        verbs: if std.type(verbs) == "array" then verbs else [verbs],
       },
       // name is the plural name of the resource.
       name(name):: {name: name},
@@ -39,7 +39,7 @@
         kind +
       {
         groupVersion: groupVersion,
-        resources: if std.type(resources) == "array" then {resources: resources} else {resources: [resources]},
+        resources: if std.type(resources) == "array" then resources else [resources],
       },
       // groupVersion is the group and version this APIResourceList is for.
       groupVersion(groupVersion):: {groupVersion: groupVersion},
@@ -145,7 +145,7 @@
     cephFSVolumeSource:: {
       default(monitors)::
       {
-        monitors: if std.type(monitors) == "array" then {monitors: monitors} else {monitors: [monitors]},
+        monitors: if std.type(monitors) == "array" then monitors else [monitors],
         secretRef: {},
       },
       // Required: Monitors is a collection of Ceph monitors More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it
@@ -515,7 +515,7 @@
       default(targetWWNs, lun)::
       {
         lun: lun,
-        targetWWNs: if std.type(targetWWNs) == "array" then {targetWWNs: targetWWNs} else {targetWWNs: [targetWWNs]},
+        targetWWNs: if std.type(targetWWNs) == "array" then targetWWNs else [targetWWNs],
       },
       // Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
       fsType(fsType):: {fsType: fsType},
@@ -721,7 +721,7 @@
     initializers:: {
       default(pending)::
       {
-        pending: if std.type(pending) == "array" then {pending: pending} else {pending: [pending]},
+        pending: if std.type(pending) == "array" then pending else [pending],
         result: {},
       },
       // Pending is a list of initializers that must execute in order before this object is visible. When the last pending initializer is removed, and no failing result is set, the initializers struct will be set to nil and the object is considered as initialized and visible to all clients.
@@ -845,7 +845,7 @@
     nodeSelector:: {
       default(nodeSelectorTerms)::
       {
-        nodeSelectorTerms: if std.type(nodeSelectorTerms) == "array" then {nodeSelectorTerms: nodeSelectorTerms} else {nodeSelectorTerms: [nodeSelectorTerms]},
+        nodeSelectorTerms: if std.type(nodeSelectorTerms) == "array" then nodeSelectorTerms else [nodeSelectorTerms],
       },
       // Required. A list of node selector terms. The terms are ORed.
       nodeSelectorTerms(nodeSelectorTerms):: if std.type(nodeSelectorTerms) == "array" then {nodeSelectorTerms+: nodeSelectorTerms} else {nodeSelectorTerms+: [nodeSelectorTerms]},
@@ -867,7 +867,7 @@
     nodeSelectorTerm:: {
       default(matchExpressions)::
       {
-        matchExpressions: if std.type(matchExpressions) == "array" then {matchExpressions: matchExpressions} else {matchExpressions: [matchExpressions]},
+        matchExpressions: if std.type(matchExpressions) == "array" then matchExpressions else [matchExpressions],
       },
       // Required. A list of node selector requirements. The requirements are ANDed.
       matchExpressions(matchExpressions):: if std.type(matchExpressions) == "array" then {matchExpressions+: matchExpressions} else {matchExpressions+: [matchExpressions]},
@@ -1157,7 +1157,7 @@
       default(containers)::
       {
         affinity: {},
-        containers: if std.type(containers) == "array" then {containers: containers} else {containers: [containers]},
+        containers: if std.type(containers) == "array" then containers else [containers],
         hostMappings: [],
         imagePullSecrets: [],
         initContainers: [],
@@ -1368,7 +1368,7 @@
     projectedVolumeSource:: {
       default(sources)::
       {
-        sources: if std.type(sources) == "array" then {sources: sources} else {sources: [sources]},
+        sources: if std.type(sources) == "array" then sources else [sources],
       },
       // Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
       defaultMode(defaultMode):: {defaultMode: defaultMode},
@@ -1396,7 +1396,7 @@
       default(monitors, image)::
       {
         image: image,
-        monitors: if std.type(monitors) == "array" then {monitors: monitors} else {monitors: [monitors]},
+        monitors: if std.type(monitors) == "array" then monitors else [monitors],
         secretRef: {},
       },
       // Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
@@ -2094,7 +2094,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // Items is the list of Deployments.
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -2342,7 +2342,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // 
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},

--- a/ksonnet.beta.1/core.v1.libsonnet
+++ b/ksonnet.beta.1/core.v1.libsonnet
@@ -19,7 +19,7 @@
         namespaced: namespaced,
         shortNames: [],
         singularName: singularName,
-        verbs: if std.type(verbs) == "array" then {verbs: verbs} else {verbs: [verbs]},
+        verbs: if std.type(verbs) == "array" then verbs else [verbs],
       },
       // name is the plural name of the resource.
       name(name):: {name: name},
@@ -39,7 +39,7 @@
         kind +
       {
         groupVersion: groupVersion,
-        resources: if std.type(resources) == "array" then {resources: resources} else {resources: [resources]},
+        resources: if std.type(resources) == "array" then resources else [resources],
       },
       // groupVersion is the group and version this APIResourceList is for.
       groupVersion(groupVersion):: {groupVersion: groupVersion},
@@ -197,7 +197,7 @@
     cephFSVolumeSource:: {
       default(monitors)::
       {
-        monitors: if std.type(monitors) == "array" then {monitors: monitors} else {monitors: [monitors]},
+        monitors: if std.type(monitors) == "array" then monitors else [monitors],
         secretRef: {},
       },
       // Required: Monitors is a collection of Ceph monitors More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it
@@ -286,7 +286,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // List of ComponentStatus objects.
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -356,7 +356,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // Items is the list of ConfigMaps.
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -497,7 +497,7 @@
     containerImage:: {
       default(names)::
       {
-        names: if std.type(names) == "array" then {names: names} else {names: [names]},
+        names: if std.type(names) == "array" then names else [names],
       },
       // Names by which this image is known. e.g. ["gcr.io/google_containers/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
       names(names):: if std.type(names) == "array" then {names+: names} else {names+: [names]},
@@ -769,7 +769,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        subsets: if std.type(subsets) == "array" then {subsets: subsets} else {subsets: [subsets]},
+        subsets: if std.type(subsets) == "array" then subsets else [subsets],
       },
       // The set of all endpoints is the union of all subsets. Addresses are placed into subsets according to the IPs they share. A single address with multiple ports, some of which are ready and some of which are not (because they come from different containers) will result in the address being displayed in different subsets for the different ports. No address will appear in both Addresses and NotReadyAddresses in the same subset. Sets of addresses and ports that comprise a service.
       subsets(subsets):: if std.type(subsets) == "array" then {subsets+: subsets} else {subsets+: [subsets]},
@@ -802,7 +802,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // List of endpoints.
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -970,7 +970,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // List of events
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -1000,7 +1000,7 @@
       default(targetWWNs, lun)::
       {
         lun: lun,
-        targetWWNs: if std.type(targetWWNs) == "array" then {targetWWNs: targetWWNs} else {targetWWNs: [targetWWNs]},
+        targetWWNs: if std.type(targetWWNs) == "array" then targetWWNs else [targetWWNs],
       },
       // Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
       fsType(fsType):: {fsType: fsType},
@@ -1208,7 +1208,7 @@
     initializers:: {
       default(pending)::
       {
-        pending: if std.type(pending) == "array" then {pending: pending} else {pending: [pending]},
+        pending: if std.type(pending) == "array" then pending else [pending],
         result: {},
       },
       // Pending is a list of initializers that must execute in order before this object is visible. When the last pending initializer is removed, and no failing result is set, the initializers struct will be set to nil and the object is considered as initialized and visible to all clients.
@@ -1355,7 +1355,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // Items is a list of LimitRange objects. More info: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/admission_control_limit_range.md
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -1370,7 +1370,7 @@
     limitRangeSpec:: {
       default(limits)::
       {
-        limits: if std.type(limits) == "array" then {limits: limits} else {limits: [limits]},
+        limits: if std.type(limits) == "array" then limits else [limits],
       },
       // Limits is the list of LimitRangeItem objects that are enforced.
       limits(limits):: if std.type(limits) == "array" then {limits+: limits} else {limits+: [limits]},
@@ -1463,7 +1463,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // Items is the list of Namespace objects in the list. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -1612,7 +1612,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // List of nodes
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -1627,7 +1627,7 @@
     nodeSelector:: {
       default(nodeSelectorTerms)::
       {
-        nodeSelectorTerms: if std.type(nodeSelectorTerms) == "array" then {nodeSelectorTerms: nodeSelectorTerms} else {nodeSelectorTerms: [nodeSelectorTerms]},
+        nodeSelectorTerms: if std.type(nodeSelectorTerms) == "array" then nodeSelectorTerms else [nodeSelectorTerms],
       },
       // Required. A list of node selector terms. The terms are ORed.
       nodeSelectorTerms(nodeSelectorTerms):: if std.type(nodeSelectorTerms) == "array" then {nodeSelectorTerms+: nodeSelectorTerms} else {nodeSelectorTerms+: [nodeSelectorTerms]},
@@ -1649,7 +1649,7 @@
     nodeSelectorTerm:: {
       default(matchExpressions)::
       {
-        matchExpressions: if std.type(matchExpressions) == "array" then {matchExpressions: matchExpressions} else {matchExpressions: [matchExpressions]},
+        matchExpressions: if std.type(matchExpressions) == "array" then matchExpressions else [matchExpressions],
       },
       // Required. A list of node selector requirements. The requirements are ANDed.
       matchExpressions(matchExpressions):: if std.type(matchExpressions) == "array" then {matchExpressions+: matchExpressions} else {matchExpressions+: [matchExpressions]},
@@ -1998,7 +1998,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // A list of persistent volume claims. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -2070,7 +2070,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // List of persistent volumes. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -2468,7 +2468,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // List of pods. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -2514,7 +2514,7 @@
       default(containers)::
       {
         affinity: {},
-        containers: if std.type(containers) == "array" then {containers: containers} else {containers: [containers]},
+        containers: if std.type(containers) == "array" then containers else [containers],
         hostMappings: [],
         imagePullSecrets: [],
         initContainers: [],
@@ -2658,7 +2658,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // List of pod templates
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -2809,7 +2809,7 @@
     projectedVolumeSource:: {
       default(sources)::
       {
-        sources: if std.type(sources) == "array" then {sources: sources} else {sources: [sources]},
+        sources: if std.type(sources) == "array" then sources else [sources],
       },
       // Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
       defaultMode(defaultMode):: {defaultMode: defaultMode},
@@ -2837,7 +2837,7 @@
       default(monitors, image)::
       {
         image: image,
-        monitors: if std.type(monitors) == "array" then {monitors: monitors} else {monitors: [monitors]},
+        monitors: if std.type(monitors) == "array" then monitors else [monitors],
         secretRef: {},
       },
       // Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
@@ -2939,7 +2939,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // List of replication controllers. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -3056,7 +3056,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // Items is a list of ResourceQuota objects. More info: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/admission_control_resource_quota.md
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -3269,7 +3269,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // Items is a list of secret objects. More info: https://kubernetes.io/docs/concepts/configuration/secret
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -3440,7 +3440,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // List of ServiceAccounts. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -3459,7 +3459,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // List of services
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},

--- a/ksonnet.beta.1/extensions.v1beta1.libsonnet
+++ b/ksonnet.beta.1/extensions.v1beta1.libsonnet
@@ -19,7 +19,7 @@
         namespaced: namespaced,
         shortNames: [],
         singularName: singularName,
-        verbs: if std.type(verbs) == "array" then {verbs: verbs} else {verbs: [verbs]},
+        verbs: if std.type(verbs) == "array" then verbs else [verbs],
       },
       // name is the plural name of the resource.
       name(name):: {name: name},
@@ -39,7 +39,7 @@
         kind +
       {
         groupVersion: groupVersion,
-        resources: if std.type(resources) == "array" then {resources: resources} else {resources: [resources]},
+        resources: if std.type(resources) == "array" then resources else [resources],
       },
       // groupVersion is the group and version this APIResourceList is for.
       groupVersion(groupVersion):: {groupVersion: groupVersion},
@@ -145,7 +145,7 @@
     cephFSVolumeSource:: {
       default(monitors)::
       {
-        monitors: if std.type(monitors) == "array" then {monitors: monitors} else {monitors: [monitors]},
+        monitors: if std.type(monitors) == "array" then monitors else [monitors],
         secretRef: {},
       },
       // Required: Monitors is a collection of Ceph monitors More info: https://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it
@@ -515,7 +515,7 @@
       default(targetWWNs, lun)::
       {
         lun: lun,
-        targetWWNs: if std.type(targetWWNs) == "array" then {targetWWNs: targetWWNs} else {targetWWNs: [targetWWNs]},
+        targetWWNs: if std.type(targetWWNs) == "array" then targetWWNs else [targetWWNs],
       },
       // Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
       fsType(fsType):: {fsType: fsType},
@@ -721,7 +721,7 @@
     initializers:: {
       default(pending)::
       {
-        pending: if std.type(pending) == "array" then {pending: pending} else {pending: [pending]},
+        pending: if std.type(pending) == "array" then pending else [pending],
         result: {},
       },
       // Pending is a list of initializers that must execute in order before this object is visible. When the last pending initializer is removed, and no failing result is set, the initializers struct will be set to nil and the object is considered as initialized and visible to all clients.
@@ -859,7 +859,7 @@
     nodeSelector:: {
       default(nodeSelectorTerms)::
       {
-        nodeSelectorTerms: if std.type(nodeSelectorTerms) == "array" then {nodeSelectorTerms: nodeSelectorTerms} else {nodeSelectorTerms: [nodeSelectorTerms]},
+        nodeSelectorTerms: if std.type(nodeSelectorTerms) == "array" then nodeSelectorTerms else [nodeSelectorTerms],
       },
       // Required. A list of node selector terms. The terms are ORed.
       nodeSelectorTerms(nodeSelectorTerms):: if std.type(nodeSelectorTerms) == "array" then {nodeSelectorTerms+: nodeSelectorTerms} else {nodeSelectorTerms+: [nodeSelectorTerms]},
@@ -881,7 +881,7 @@
     nodeSelectorTerm:: {
       default(matchExpressions)::
       {
-        matchExpressions: if std.type(matchExpressions) == "array" then {matchExpressions: matchExpressions} else {matchExpressions: [matchExpressions]},
+        matchExpressions: if std.type(matchExpressions) == "array" then matchExpressions else [matchExpressions],
       },
       // Required. A list of node selector requirements. The requirements are ANDed.
       matchExpressions(matchExpressions):: if std.type(matchExpressions) == "array" then {matchExpressions+: matchExpressions} else {matchExpressions+: [matchExpressions]},
@@ -1076,7 +1076,7 @@
       default(containers)::
       {
         affinity: {},
-        containers: if std.type(containers) == "array" then {containers: containers} else {containers: [containers]},
+        containers: if std.type(containers) == "array" then containers else [containers],
         hostMappings: [],
         imagePullSecrets: [],
         initContainers: [],
@@ -1287,7 +1287,7 @@
     projectedVolumeSource:: {
       default(sources)::
       {
-        sources: if std.type(sources) == "array" then {sources: sources} else {sources: [sources]},
+        sources: if std.type(sources) == "array" then sources else [sources],
       },
       // Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
       defaultMode(defaultMode):: {defaultMode: defaultMode},
@@ -1317,7 +1317,7 @@
       default(monitors, image)::
       {
         image: image,
-        monitors: if std.type(monitors) == "array" then {monitors: monitors} else {monitors: [monitors]},
+        monitors: if std.type(monitors) == "array" then monitors else [monitors],
         secretRef: {},
       },
       // Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
@@ -1997,7 +1997,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // A list of daemon sets.
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -2168,7 +2168,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // Items is the list of Deployments.
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -2319,7 +2319,7 @@
     hTTPIngressRuleValue:: {
       default(paths)::
       {
-        paths: if std.type(paths) == "array" then {paths: paths} else {paths: [paths]},
+        paths: if std.type(paths) == "array" then paths else [paths],
       },
       // A collection of paths that map requests to backends.
       paths(paths):: if std.type(paths) == "array" then {paths+: paths} else {paths+: [paths]},
@@ -2410,7 +2410,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // Items is the list of Ingress.
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -2544,7 +2544,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // Items is a list of schema objects.
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -2664,7 +2664,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // Items is a list of schema objects.
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -2816,7 +2816,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},
@@ -3033,7 +3033,7 @@
         kind +
         defaultMetadata(name, namespace) +
       {
-        items: if std.type(items) == "array" then {items: items} else {items: [items]},
+        items: if std.type(items) == "array" then items else [items],
       },
       // Items is the list of ThirdPartyResources.
       items(items):: if std.type(items) == "array" then {items+: items} else {items+: [items]},


### PR DESCRIPTION
When arguments to `default` require an array, we will erroneously nest
the property inside itself, so that `{foo: "bar"}` turns into
`{foo: {foo: bar}}`.

This commit corrects this.