### PR TITLE
Emit comments, implement property blacklisting/rewriting

### DIFF
--- a/ksonnet-gen/jsonnet/rewrite.go
+++ b/ksonnet-gen/jsonnet/rewrite.go
@@ -1,0 +1,128 @@
+// Package jsonnet contains a collection of simple rewriting
+// facilities that allow us to easily map text from the OpenAPI spec
+// to things that are Jsonnet-friendly (e.g., renaming identifiers
+// that are Jsonnet keywords, lowerCamelCase'ing names, and so on).
+package jsonnet
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+	"strings"
+
+	"github.com/ksonnet/ksonnet-lib/ksonnet-gen/kubespec"
+	"github.com/ksonnet/ksonnet-lib/ksonnet-gen/kubeversion"
+)
+
+// FieldKey represents the literal text of a key for some JSON object
+// field, after rewriting to avoid collisions with Jsonnet keywords.
+// For example, for `{foo: ...}`, the `FieldKey` would be `foo`, while
+// for `{error: ...}`, the `FieldKey` would be `"error"` (with
+// quotation marks, to avoid collisions).
+type FieldKey string
+
+// FuncParam represents the parameter to a Jsonnet function, after
+// being rewritten to avoid collisions with Jsonnet keywords and
+// normalized to fit the Jsonnet style (i.e., lowerCamelCase) using a
+// manual set of custom transformations that change per Kubernetes
+// version. For example, in `foo(BarAPI) {...}`, `FuncParam` would be
+// `barApi`, and in `foo(error) {...}`, `FuncParam` would be
+// `errorParam`.
+type FuncParam string
+
+// Identifier represents any identifier in a Jsonnet program, after
+// being normalized to fit the Jsonnet style (i.e., lowerCamelCase)
+// using a manual set of custom transformations that change per
+// Kubernetes version. For example, `fooAPI` becomes `fooApi`.
+type Identifier string
+
+// RewriteAsFieldKey takes a `PropertyName` and converts it to a valid
+// Jsonnet field name. For example, if the `PropertyName` has a value
+// of `"error"`, then this would generate an invalid object, `{error:
+// ...}`. Hence, this function will quote this string, so that it ends
+// up like: `{"error": ...}`.
+func RewriteAsFieldKey(text kubespec.PropertyName) FieldKey {
+	// NOTE: Because the field needs to have precisely the same text as
+	// the Kubernetes API spec, we do not compute a version-specific ID
+	// alias as we do for other rewrites.
+	if _, ok := jsonnetKeywordSet[text]; ok {
+		return FieldKey(fmt.Sprintf("\"%s\"", text))
+	}
+	return FieldKey(text)
+}
+
+// RewriteAsFuncParam takes a `PropertyName` and converts it to a
+// valid Jsonnet function parameter. For example, if the
+// `PropertyName` has a value of `"error"`, then this would generate
+// an invalid function parameter, `function(error) ...`. Hence, this
+// function will alter the identifier, so that it ends up like:
+// `function(errorParam) ...`.
+//
+// NOTE: This transformation involves a hand-curated style change to
+// lowerCamelCase (e.g., `fooAPI` -> `fooApi`). This list changes per
+// Kubernetes version, according to identifiers that don't conform to
+// this style.
+func RewriteAsFuncParam(
+	k8sVersion string, text kubespec.PropertyName,
+) FuncParam {
+	id := RewriteAsIdentifier(k8sVersion, string(text))
+	if _, ok := jsonnetKeywordSet[kubespec.PropertyName(id)]; ok {
+		return FuncParam(fmt.Sprintf("%sParam", id))
+	}
+	return FuncParam(id)
+}
+
+// RewriteAsIdentifier takes a `GroupName`, `ObjectKind`,
+// `PropertyName`, or `string`, and converts it to a Jsonnet-style
+// Identifier. Typically this includes lower-casing the first letter,
+// but also changing initialisms like fooAPI -> fooApi.
+//
+// NOTE: This transformation involves a hand-curated style change to
+// lowerCamelCase (e.g., `fooAPI` -> `fooApi`). This list changes per
+// Kubernetes version, according to identifiers that don't conform to
+// this style.
+func RewriteAsIdentifier(
+	k8sVersion string, rawID interface{},
+) Identifier {
+	var id string
+	switch rawID.(type) {
+	case kubespec.GroupName:
+		id = string(rawID.(kubespec.GroupName))
+	case kubespec.ObjectKind:
+		id = string(rawID.(kubespec.ObjectKind))
+	case kubespec.PropertyName:
+		id = string(rawID.(kubespec.PropertyName))
+	case string:
+		id = rawID.(string)
+	default:
+		log.Fatalf("Can't rewrite identifier of type '%s'", reflect.TypeOf(rawID))
+	}
+
+	if len(id) == 0 {
+		log.Fatalf("Can't lowercase first letter of 0-rune string")
+	}
+	kindString := kubeversion.MapIdentifier(k8sVersion, id)
+
+	upper := strings.ToLower(kindString[:1])
+	return Identifier(upper + kindString[1:])
+}
+
+var jsonnetKeywordSet = map[kubespec.PropertyName]string{
+	"assert":     "assert",
+	"else":       "else",
+	"error":      "error",
+	"false":      "false",
+	"for":        "for",
+	"function":   "function",
+	"if":         "if",
+	"import":     "import",
+	"importstr":  "importstr",
+	"in":         "in",
+	"local":      "local",
+	"null":       "null",
+	"tailstrict": "tailstrict",
+	"then":       "then",
+	"self":       "self",
+	"super":      "super",
+	"true":       "true",
+}

--- a/ksonnet-gen/jsonnet/rewrite.go
+++ b/ksonnet-gen/jsonnet/rewrite.go
@@ -7,7 +7,6 @@ package jsonnet
 import (
 	"fmt"
 	"log"
-	"reflect"
 	"strings"
 
 	"github.com/ksonnet/ksonnet-lib/ksonnet-gen/kubespec"
@@ -65,7 +64,7 @@ func RewriteAsFieldKey(text kubespec.PropertyName) FieldKey {
 func RewriteAsFuncParam(
 	k8sVersion string, text kubespec.PropertyName,
 ) FuncParam {
-	id := RewriteAsIdentifier(k8sVersion, string(text))
+	id := RewriteAsIdentifier(k8sVersion, text)
 	if _, ok := jsonnetKeywordSet[kubespec.PropertyName(id)]; ok {
 		return FuncParam(fmt.Sprintf("%sParam", id))
 	}
@@ -82,21 +81,9 @@ func RewriteAsFuncParam(
 // Kubernetes version, according to identifiers that don't conform to
 // this style.
 func RewriteAsIdentifier(
-	k8sVersion string, rawID interface{},
+	k8sVersion string, rawID fmt.Stringer,
 ) Identifier {
-	var id string
-	switch rawID.(type) {
-	case kubespec.GroupName:
-		id = string(rawID.(kubespec.GroupName))
-	case kubespec.ObjectKind:
-		id = string(rawID.(kubespec.ObjectKind))
-	case kubespec.PropertyName:
-		id = string(rawID.(kubespec.PropertyName))
-	case string:
-		id = rawID.(string)
-	default:
-		log.Fatalf("Can't rewrite identifier of type '%s'", reflect.TypeOf(rawID))
-	}
+	var id = rawID.String()
 
 	if len(id) == 0 {
 		log.Fatalf("Can't lowercase first letter of 0-rune string")

--- a/ksonnet-gen/jsonnet/rewrite_test.go
+++ b/ksonnet-gen/jsonnet/rewrite_test.go
@@ -1,0 +1,120 @@
+package jsonnet
+
+import "testing"
+import "github.com/ksonnet/ksonnet-lib/ksonnet-gen/kubespec"
+
+var fieldKeyTests = map[kubespec.PropertyName]FieldKey{
+	"assert":     "\"assert\"",
+	"else":       "\"else\"",
+	"error":      "\"error\"",
+	"false":      "\"false\"",
+	"for":        "\"for\"",
+	"function":   "\"function\"",
+	"if":         "\"if\"",
+	"import":     "\"import\"",
+	"importstr":  "\"importstr\"",
+	"in":         "\"in\"",
+	"local":      "\"local\"",
+	"null":       "\"null\"",
+	"tailstrict": "\"tailstrict\"",
+	"then":       "\"then\"",
+	"self":       "\"self\"",
+	"super":      "\"super\"",
+	"true":       "\"true\"",
+}
+
+var funcParamTests = map[kubespec.PropertyName]FuncParam{
+	"assert":     "assertParam",
+	"else":       "elseParam",
+	"error":      "errorParam",
+	"false":      "falseParam",
+	"for":        "forParam",
+	"function":   "functionParam",
+	"if":         "ifParam",
+	"import":     "importParam",
+	"importstr":  "importstrParam",
+	"in":         "inParam",
+	"local":      "localParam",
+	"null":       "nullParam",
+	"tailstrict": "tailstrictParam",
+	"then":       "thenParam",
+	"self":       "selfParam",
+	"super":      "superParam",
+	"true":       "trueParam",
+}
+
+var identifierTests = map[kubespec.PropertyName]Identifier{
+	"hostIPC":                        "hostIpc",
+	"hostPID":                        "hostPid",
+	"targetCPUUtilizationPercentage": "targetCpuUtilizationPercentage",
+	"externalID":                     "externalId",
+	"podCIDR":                        "podCidr",
+	"providerID":                     "providerId",
+	"bootID":                         "bootId",
+	"machineID":                      "machineId",
+	"systemUUID":                     "systemUuid",
+	"volumeID":                       "volumeId",
+	"diskURI":                        "diskUri",
+	"targetWWNs":                     "targetWwns",
+	"datasetUUID":                    "datasetUuid",
+	"pdID":                           "pdId",
+	"scaleIO":                        "scaleIo",
+	"podIP":                          "podIp",
+	"hostIP":                         "hostIp",
+	"clusterIP":                      "clusterIp",
+	"externalIPs":                    "externalIps",
+	"loadBalancerIP":                 "loadBalancerIp",
+}
+
+func TestRewriteAsFieldKey(t *testing.T) {
+	for keyword, target := range fieldKeyTests {
+		actual := RewriteAsFieldKey(keyword)
+		if target != actual {
+			t.Errorf("Expected '%s' got '%s'", target, actual)
+		}
+	}
+
+	// Test rewrite is a no-op for other identifiers.
+	for id := range identifierTests {
+		target := FieldKey(id)
+		actual := RewriteAsFieldKey(kubespec.PropertyName(id))
+		if target != actual {
+			t.Errorf("Expected '%s' got '%s'", target, actual)
+		}
+	}
+}
+
+func TestRewriteAsFuncParam(t *testing.T) {
+	for keyword, target := range funcParamTests {
+		actual := RewriteAsFuncParam("v1.7.0", keyword)
+		if target != actual {
+			t.Errorf("Expected '%s' got '%s'", target, actual)
+		}
+	}
+
+	// Test we also do aliasing for func parameters
+	for id, target := range identifierTests {
+		actual := RewriteAsFuncParam("v1.7.0", id)
+		if FuncParam(target) != actual {
+			t.Errorf("Expected '%s' got '%s'", target, actual)
+		}
+	}
+}
+
+func TestRewriteAsIdentifier(t *testing.T) {
+	for id, target := range identifierTests {
+		actual := RewriteAsIdentifier("v1.7.0", id)
+		if target != actual {
+			t.Errorf("Expected '%s' got '%s'", target, actual)
+		}
+	}
+
+	// Test rewrite is a no-op for keywords.
+	for keyword := range fieldKeyTests {
+		target := Identifier(keyword)
+		actual := RewriteAsIdentifier("v1.7.0", kubespec.PropertyName(keyword))
+		if target != actual {
+			t.Errorf("Expected '%s' got '%s'", target, actual)
+		}
+	}
+}

--- a/ksonnet-gen/ksonnet/emit.go
+++ b/ksonnet-gen/ksonnet/emit.go
@@ -205,22 +205,10 @@ func (gs groupSet) toSortedSlice() groupSlice {
 	for _, group := range gs {
 		groups = append(groups, group)
 	}
-	sort.Sort(groups)
+	sort.Slice(groups, func(i, j int) bool {
+		return groups[i].name < groups[j].name
+	})
 	return groups
-}
-
-//
-// sort.Interface implementation for groupSlice.
-//
-
-func (gs groupSlice) Len() int {
-	return len(gs)
-}
-func (gs groupSlice) Swap(i, j int) {
-	gs[i], gs[j] = gs[j], gs[i]
-}
-func (gs groupSlice) Less(i, j int) bool {
-	return gs[i].name < gs[j].name
 }
 
 //-----------------------------------------------------------------------------

--- a/ksonnet-gen/ksonnet/util.go
+++ b/ksonnet-gen/ksonnet/util.go
@@ -20,16 +20,6 @@ func isSpecialProperty(pn kubespec.PropertyName) bool {
 	return ok
 }
 
-func toJsonnetName(ok kubespec.ObjectKind) kubespec.ObjectKind {
-	if len(ok) == 0 {
-		log.Fatalf("Can't lowercase first letter of 0-rune string")
-	}
-	kindString := string(ok)
-
-	upper := strings.ToLower(kindString[:1])
-	return kubespec.ObjectKind(upper + kindString[1:])
-}
-
 func getSHARevision(dir string) string {
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/ksonnet-gen/kubespec/parsing.go
+++ b/ksonnet-gen/kubespec/parsing.go
@@ -155,13 +155,25 @@ type ParsedDefinitionName struct {
 // extensions, etc.)
 type GroupName string
 
+func (gn GroupName) String() string {
+	return string(gn)
+}
+
 // ObjectKind represents the `kind` of a Kubernetes API object (e.g.,
 // Service, Deployment, etc.)
 type ObjectKind string
 
+func (ok ObjectKind) String() string {
+	return string(ok)
+}
+
 // VersionString is the string representation of an API version (e.g.,
 // v1, v1beta1, etc.)
 type VersionString string
+
+func (vs VersionString) String() string {
+	return string(vs)
+}
 
 // Unparse transforms a `ParsedDefinitionName` back into its
 // corresponding string, e.g.,

--- a/ksonnet-gen/kubespec/swagger.go
+++ b/ksonnet-gen/kubespec/swagger.go
@@ -73,14 +73,30 @@ type Items map[string]string
 // example, a property might have type `string`.
 type SchemaType string
 
+func (st SchemaType) String() string {
+	return string(st)
+}
+
 // ObjectRef represents a reference to some API object. For example,
 // `#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta`
 type ObjectRef string
+
+func (or ObjectRef) String() string {
+	return string(or)
+}
 
 // PropertyName represents the name of a property. For example,
 // `apiVersion` or `kind`.
 type PropertyName string
 
+func (pn PropertyName) String() string {
+	return string(pn)
+}
+
 // DefinitionName represents the name of a definition. For example,
 // `v1.APIGroup`.
 type DefinitionName string
+
+func (dn DefinitionName) String() string {
+	return string(dn)
+}

--- a/ksonnet-gen/kubeversion/data.go
+++ b/ksonnet-gen/kubeversion/data.go
@@ -5,9 +5,9 @@ package kubeversion
 // emitted.
 //-----------------------------------------------------------------------------
 
-var versions = versionSet{
+var versions = map[string]versionData{
 	"v1.7.0": versionData{
-		idAliases: idAliasSet{
+		idAliases: map[string]string{
 			"hostIPC":                        "hostIpc",
 			"hostPID":                        "hostPid",
 			"targetCPUUtilizationPercentage": "targetCpuUtilizationPercentage",
@@ -29,7 +29,7 @@ var versions = versionSet{
 			"externalIPs":                    "externalIps",
 			"loadBalancerIP":                 "loadBalancerIp",
 		},
-		propertyBlacklist: blackList{
+		propertyBlacklist: map[string]propertySet{
 			"io.k8s.kubernetes.pkg.apis.apps.v1beta1.Deployment": newPropertySet("status"),
 		},
 	},

--- a/ksonnet-gen/kubeversion/data.go
+++ b/ksonnet-gen/kubeversion/data.go
@@ -1,0 +1,36 @@
+package kubeversion
+
+//-----------------------------------------------------------------------------
+// Kubernetes version-specific data for customizing code that's
+// emitted.
+//-----------------------------------------------------------------------------
+
+var versions = versionSet{
+	"v1.7.0": versionData{
+		idAliases: idAliasSet{
+			"hostIPC":                        "hostIpc",
+			"hostPID":                        "hostPid",
+			"targetCPUUtilizationPercentage": "targetCpuUtilizationPercentage",
+			"externalID":                     "externalId",
+			"podCIDR":                        "podCidr",
+			"providerID":                     "providerId",
+			"bootID":                         "bootId",
+			"machineID":                      "machineId",
+			"systemUUID":                     "systemUuid",
+			"volumeID":                       "volumeId",
+			"diskURI":                        "diskUri",
+			"targetWWNs":                     "targetWwns",
+			"datasetUUID":                    "datasetUuid",
+			"pdID":                           "pdId",
+			"scaleIO":                        "scaleIo",
+			"podIP":                          "podIp",
+			"hostIP":                         "hostIp",
+			"clusterIP":                      "clusterIp",
+			"externalIPs":                    "externalIps",
+			"loadBalancerIP":                 "loadBalancerIp",
+		},
+		propertyBlacklist: blackList{
+			"io.k8s.kubernetes.pkg.apis.apps.v1beta1.Deployment": newPropertySet("status"),
+		},
+	},
+}

--- a/ksonnet-gen/kubeversion/version.go
+++ b/ksonnet-gen/kubeversion/version.go
@@ -1,0 +1,80 @@
+// Package kubeversion contains a collection of helper methods that
+// help to customize the code generated for ksonnet-lib to suit
+// different Kubernetes versions.
+//
+// For example, we may choose not to emit certain properties for some
+// objects in Kubernetes v1.7.0; or, we might want to rename a
+// property method. This package contains both the helper methods that
+// perform such transformations, as well as the data for the
+// transformations we use for each version.
+package kubeversion
+
+import (
+	"log"
+
+	"github.com/ksonnet/ksonnet-lib/ksonnet-gen/kubespec"
+)
+
+// MapIdentifier takes a text identifier and maps it to a
+// Jsonnet-appropriate identifier, for some version of Kubernetes. For
+// example, in Kubernetes v1.7.0, we might map `clusterIP` ->
+// `clusterIp`.
+func MapIdentifier(k8sVersion, id string) string {
+	verData, ok := versions[k8sVersion]
+	if !ok {
+		log.Fatalf("Unrecognized Kubernetes version '%s'", k8sVersion)
+	}
+
+	if alias, ok := verData.idAliases[id]; ok {
+		return alias
+	}
+	return id
+}
+
+// IsBlacklistedProperty taks a definition name (e.g.,
+// `io.k8s.kubernetes.pkg.apis.apps.v1beta1.Deployment`), a property
+// name (e.g., `status`), and reports whether it is blacklisted for
+// some Kubernetes version. This is particularly useful when deciding
+// whether or not to generate mixins and property methods for a given
+// property (as we likely wouldn't in the case of, say, `status`).
+func IsBlacklistedProperty(
+	k8sVersion string, path kubespec.DefinitionName,
+	propertyName kubespec.PropertyName,
+) bool {
+	verData, ok := versions[k8sVersion]
+	if !ok {
+		return false
+	}
+
+	bl, ok := verData.propertyBlacklist[string(path)]
+	if !ok {
+		return false
+	}
+
+	_, ok = bl[string(propertyName)]
+	return ok
+}
+
+//-----------------------------------------------------------------------------
+// Core data structures for specifying version information.
+//-----------------------------------------------------------------------------
+
+type versionSet map[string]versionData
+
+type versionData struct {
+	idAliases         idAliasSet
+	propertyBlacklist blackList
+}
+
+type idAliasSet map[string]string
+type propertySet map[string]bool
+type blackList map[string]propertySet
+
+func newPropertySet(strings ...string) propertySet {
+	ps := make(propertySet)
+	for _, s := range strings {
+		ps[s] = true
+	}
+
+	return ps
+}

--- a/ksonnet-gen/kubeversion/version.go
+++ b/ksonnet-gen/kubeversion/version.go
@@ -59,16 +59,12 @@ func IsBlacklistedProperty(
 // Core data structures for specifying version information.
 //-----------------------------------------------------------------------------
 
-type versionSet map[string]versionData
-
 type versionData struct {
-	idAliases         idAliasSet
-	propertyBlacklist blackList
+	idAliases         map[string]string
+	propertyBlacklist map[string]propertySet
 }
 
-type idAliasSet map[string]string
 type propertySet map[string]bool
-type blackList map[string]propertySet
 
 func newPropertySet(strings ...string) propertySet {
 	ps := make(propertySet)


### PR DESCRIPTION
I'll quote the most consequential commit in this series to give context:

```
When we emit `ksonnet-lib`, it is very useful to have the ability to
elide properties that the client should not be using (such as the
`status` field in `io.k8s.kubernetes.pkg.apis.apps.v1beta1.Deployment`),
and to rename properties that are either problematic (such as any
property whose name is a Jsonnet identifier) or not Jsonnet-style (such
as `podIP`).

This commit will implement this behavior. Specifically, such
transformations are specified by altering `kubeversion/data.go`, which
on a per-Kubernetes-version basis specifies:

1. Which properties of any fully-qualified API object name to blacklist
   (i.e., ignore when emitting Jsonnet code).
2. Transformations for the name of any property method (e.g., changing
   the name of, say, `TokenReviewStatus.error` ->
   `tokenReviewStatus.checkError`) to avoid collisions with Jsonnet
   keywords, and to fix casing problems that are not idiomatic to
   Jsonnet.

In particular, this means that updating `ksonnet-lib` for a new version
of Kubernetes involves simply adding rules for that version in
`kubeversion/data.go`.
```