### PR TITLE
Adds a utility constructor to the namespace resource.

### DIFF
--- a/ksonnet.beta.2/k.libsonnet
+++ b/ksonnet.beta.2/k.libsonnet
@@ -81,6 +81,13 @@ k8s + {
           if std.type(items) == "array" then {items+: items} else {items: [items]},
       },
 
+      namespace:: core.v1.namespace + {
+        new(name)::
+          super.new() +
+          super.mixin.metadata.name(name) +
+          super.mixin.metadata.labels({"name": name}),
+      },
+
       service:: core.v1.service + {
         new(name, selectorLabels, ports)::
           super.new() +


### PR DESCRIPTION
Adds a label by default like in the [example documentation][1].

[1]: https://kubernetes.io/docs/tasks/administer-cluster/namespaces-walkthrough/

Signed-off-by: Chuck Ha <chuck@heptio.com>