### PR TITLE
allow statefulSet to also take advantage of the mapContainers helper machinery

### DIFF
--- a/ksonnet.beta.2/k.libsonnet
+++ b/ksonnet.beta.2/k.libsonnet
@@ -46,6 +46,11 @@ k8s + {
         mapContainers(f):: hidden.mapContainers(f),
         mapContainersWithName(names, f):: hidden.mapContainersWithName(names, f),
       },
+
+      statefulSet:: v1beta1.statefulSet + {
+        mapContainers(f):: hidden.mapContainers(f),
+        mapContainersWithName(names, f):: hidden.mapContainersWithName(names, f),
+      },
     },
   },
 
@@ -72,6 +77,11 @@ k8s + {
       },
 
       deployment:: v1beta1.deployment + {
+        mapContainers(f):: hidden.mapContainers(f),
+        mapContainersWithName(names, f):: hidden.mapContainersWithName(names, f),
+      },
+
+      statefulSet:: v1beta1.statefulSet + {
         mapContainers(f):: hidden.mapContainers(f),
         mapContainersWithName(names, f):: hidden.mapContainersWithName(names, f),
       },

--- a/ksonnet.beta.3/k.libsonnet
+++ b/ksonnet.beta.3/k.libsonnet
@@ -46,6 +46,11 @@ k8s + {
         mapContainers(f):: hidden.mapContainers(f),
         mapContainersWithName(names, f):: hidden.mapContainersWithName(names, f),
       },
+
+      statefulSet:: v1beta1.statefulSet + {
+        mapContainers(f):: hidden.mapContainers(f),
+        mapContainersWithName(names, f):: hidden.mapContainersWithName(names, f),
+      },
     },
   },
 
@@ -72,6 +77,11 @@ k8s + {
       },
 
       deployment:: v1beta1.deployment + {
+        mapContainers(f):: hidden.mapContainers(f),
+        mapContainersWithName(names, f):: hidden.mapContainersWithName(names, f),
+      },
+
+      statefulSet:: v1beta1.statefulSet + {
         mapContainers(f):: hidden.mapContainers(f),
         mapContainersWithName(names, f):: hidden.mapContainersWithName(names, f),
       },


### PR DESCRIPTION
Hi all, 

*daemonSet* and *deployment* were there so it only, IMHO, makes sense to add *statefulSet* to the party too ...
