### PR TITLE
bug fix: handle chained applies properly

### DIFF
--- a/ksonnet-gen/ksonnet/api_object.go
+++ b/ksonnet-gen/ksonnet/api_object.go
@@ -23,7 +23,7 @@ func NewAPIObject(resource Object) *APIObject {
 
 // Kind is the kind of api object this is.
 func (a *APIObject) Kind() string {
-	return formatKind(a.resource.Kind())
+	return FormatKind(a.resource.Kind())
 }
 
 // Description is the description of this API object.

--- a/ksonnet-gen/ksonnet/renderer.go
+++ b/ksonnet-gen/ksonnet/renderer.go
@@ -103,7 +103,7 @@ func (r *ReferenceRenderer) Render(container *nm.Object) error {
 
 	renderFields(r.tl, mo, name, ty.Properties())
 
-	formattedName := formatKind(r.rf.Name())
+	formattedName := FormatKind(r.rf.Name())
 
 	container.Set(nm.NewKey(formattedName, nm.KeyOptComment(desc)), mo)
 	_ = genTypeAliasEntry(container, name, ref)
@@ -127,10 +127,10 @@ func NewObjectRenderer(field Property, parent string) *ObjectRenderer {
 func (r *ObjectRenderer) Render(container *nm.Object) error {
 	wrapper := mixinName(r.parent)
 	setterFn := createObjectWithField(r.name, wrapper, false)
-	setProperty(container, r.setter(), r.description, []string{formatKind(r.name)}, setterFn)
+	setProperty(container, r.setter(), r.description, []string{FormatKind(r.name)}, setterFn)
 
 	mixinFn := createObjectWithField(r.name, wrapper, true)
-	setProperty(container, r.mixin(), r.description, []string{formatKind(r.name)}, mixinFn)
+	setProperty(container, r.mixin(), r.description, []string{FormatKind(r.name)}, mixinFn)
 
 	_ = genTypeAliasEntry(container, r.name, r.ref)
 
@@ -152,7 +152,7 @@ func NewItemRenderer(f Property, parent string) *ItemRenderer {
 // Render renders an item in its parent object.
 func (r *ItemRenderer) Render(parent *nm.Object) error {
 	noder := createObjectWithField(r.name, mixinName(r.parent), false)
-	setProperty(parent, r.setter(), r.description, []string{formatKind(r.name)}, noder)
+	setProperty(parent, r.setter(), r.description, []string{FormatKind(r.name)}, noder)
 
 	_ = genTypeAliasEntry(parent, r.name, r.ref)
 	return nil
@@ -172,10 +172,10 @@ func NewArrayRenderer(f Property, parent string) *ArrayRenderer {
 func (r *ArrayRenderer) Render(container *nm.Object) error {
 	wrapper := mixinName(r.parent)
 	setterFn := convertToArray(r.name, wrapper, false)
-	setProperty(container, r.setter(), r.description, []string{formatKind(r.name)}, setterFn)
+	setProperty(container, r.setter(), r.description, []string{FormatKind(r.name)}, setterFn)
 
 	mixinFn := convertToArray(r.name, wrapper, true)
-	setProperty(container, r.mixin(), r.description, []string{formatKind(r.name)}, mixinFn)
+	setProperty(container, r.mixin(), r.description, []string{FormatKind(r.name)}, mixinFn)
 
 	_ = genTypeAliasEntry(container, r.name, r.ref)
 	return nil
@@ -184,7 +184,7 @@ func (r *ArrayRenderer) Render(container *nm.Object) error {
 func convertToArray(varName, parent string, mixin bool) nm.Noder {
 	apply := nm.NewApply(
 		nm.NewCall("std.type"),
-		nm.NewVar(formatKind(varName)))
+		nm.NewVar(FormatKind(varName)))
 
 	test := nm.NewBinary(apply, nm.NewStringDouble("array"), nm.BopEqual)
 
@@ -194,12 +194,12 @@ func convertToArray(varName, parent string, mixin bool) nm.Noder {
 	trueO := nm.OnelineObject()
 	trueO.Set(
 		nm.InheritedKey(varName, nm.KeyOptMixin(mixin)),
-		nm.NewVar(formatKind(varName)))
+		nm.NewVar(FormatKind(varName)))
 
 	falseO := nm.OnelineObject()
 	falseO.Set(
 		nm.InheritedKey(varName, nm.KeyOptMixin(mixin)),
-		nm.NewArray([]nm.Noder{nm.NewVar(formatKind(varName))}))
+		nm.NewArray([]nm.Noder{nm.NewVar(FormatKind(varName))}))
 
 	if parent == "" {
 		trueBranch = trueO
@@ -217,7 +217,7 @@ func convertToArray(varName, parent string, mixin bool) nm.Noder {
 func createObjectWithField(name, parentName string, mixin bool) nm.Noder {
 	var noder nm.Noder
 	io := nm.OnelineObject()
-	io.Set(nm.InheritedKey(name, nm.KeyOptMixin(mixin)), nm.NewVar(formatKind(name)))
+	io.Set(nm.InheritedKey(name, nm.KeyOptMixin(mixin)), nm.NewVar(FormatKind(name)))
 
 	if parentName == "" {
 		noder = io
@@ -238,7 +238,7 @@ func mixinPreamble(o *nm.Object, parent, name string) error {
 	if o == nil {
 		return errors.New("parent object is nil")
 	}
-	name = formatKind(name)
+	name = FormatKind(name)
 
 	formattedName := mixinName(name)
 
@@ -280,7 +280,7 @@ func genTypeAliasEntry(container *nm.Object, name, refName string) error {
 			name, refName)
 	}
 
-	kind := formatKind(rd.Kind)
+	kind := FormatKind(rd.Kind)
 	path := []string{"hidden", rd.Group, rd.Version, kind}
 	location := strings.Join(path, ".")
 
@@ -309,7 +309,7 @@ func mixinName(name string) string {
 		return ""
 	}
 
-	name = formatKind(name)
+	name = FormatKind(name)
 
 	return fmt.Sprintf("__%sMixin", name)
 }

--- a/ksonnet-gen/ksonnet/strings.go
+++ b/ksonnet-gen/ksonnet/strings.go
@@ -82,7 +82,8 @@ func capitalize(in string) string {
 	return b.String()
 }
 
-func formatKind(s string) string {
+// FormatKind formats a string in kind format. i.e camel case with jsonnet keywords massaged.
+func FormatKind(s string) string {
 	if strings.ToLower(s) == "local" {
 		return "localStorage"
 	}

--- a/ksonnet-gen/ksonnet/strings_test.go
+++ b/ksonnet-gen/ksonnet/strings_test.go
@@ -131,7 +131,7 @@ func Test_capitalizer_capitalize(t *testing.T) {
 	}
 }
 
-func Test_formatKind(t *testing.T) {
+func Test_FormatKind(t *testing.T) {
 	cases := []struct {
 		name     string
 		expected string
@@ -156,7 +156,7 @@ func Test_formatKind(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := formatKind(tc.name)
+			got := FormatKind(tc.name)
 			require.Equal(t, tc.expected, got)
 		})
 	}

--- a/ksonnet-gen/nodemaker/nodemaker_test.go
+++ b/ksonnet-gen/nodemaker/nodemaker_test.go
@@ -73,6 +73,26 @@ func ExampleBinary() {
 	// }
 }
 
+func ExampleCall() {
+	o := NewObject()
+	k := NewKey("foo")
+
+	c := NewCall("a.b.c.d")
+
+	if err := o.Set(k, c); err != nil {
+		fmt.Printf("error: %#v\n", err)
+	}
+
+	if err := printer.Fprint(os.Stdout, o.Node()); err != nil {
+		fmt.Printf("error: %#v\n", err)
+	}
+
+	// Output:
+	// {
+	//   foo:: a.b.c.d,
+	// }
+}
+
 func ExampleObject() {
 	o := NewObject()
 
@@ -321,7 +341,7 @@ func mixinField() *Object {
 
 func numberField() *Object {
 	o := NewObject()
-	t := NewNumber(1)
+	t := NewInt(1)
 	k := InheritedKey("foo")
 	o.Set(k, t)
 	return o
@@ -557,7 +577,8 @@ var (
 						Hide: ast.ObjectFieldInherit,
 						Kind: ast.ObjectFieldID,
 						Expr2: &ast.LiteralNumber{
-							Value: 1,
+							Value:          1,
+							OriginalString: "1",
 						},
 					},
 				},
@@ -769,11 +790,11 @@ var (
 						Kind: ast.ObjectLocal,
 						Expr2: &ast.Apply{
 							Target: &ast.Index{
-								Id: newIdentifier("alpha"),
+								Id: newIdentifier("charlie"),
 								Target: &ast.Index{
 									Id: newIdentifier("beta"),
 									Target: &ast.Var{
-										Id: *newIdentifier("charlie"),
+										Id: *newIdentifier("alpha"),
 									},
 								},
 							},
@@ -810,8 +831,8 @@ func TestObject_Get(t *testing.T) {
 }
 
 func TestBinary_UnknownOperator(t *testing.T) {
-	left := NewNumber(1)
-	right := NewNumber(2)
+	left := NewInt(1)
+	right := NewFloat(2)
 
 	b := NewBinary(left, right, BinaryOp("☃"))
 

--- a/ksonnet-gen/printer/printer_test.go
+++ b/ksonnet-gen/printer/printer_test.go
@@ -39,6 +39,8 @@ func TestFprintf(t *testing.T) {
 		{name: "index_with_index"},
 		{name: "array"},
 		{name: "self_apply"},
+		{name: "declarations"},
+		{name: "chained_apply"},
 
 		// errors
 		{name: "unknown_node", isErr: true},
@@ -410,9 +412,9 @@ var (
 			Cond: &ast.Binary{
 				Left: &ast.Apply{
 					Target: &ast.Index{
-						Id: newIdentifier("std"),
+						Id: newIdentifier("type"),
 						Target: &ast.Var{
-							Id: *newIdentifier("type"),
+							Id: *newIdentifier("std"),
 						},
 					},
 					Arguments: ast.Arguments{
@@ -462,9 +464,9 @@ var (
 			Cond: &ast.Binary{
 				Left: &ast.Apply{
 					Target: &ast.Index{
-						Id: newIdentifier("std"),
+						Id: newIdentifier("type"),
 						Target: &ast.Var{
-							Id: *newIdentifier("type"),
+							Id: *newIdentifier("std"),
 						},
 					},
 					Arguments: ast.Arguments{
@@ -503,6 +505,69 @@ var (
 			},
 		},
 		"self_apply": &ast.Apply{Target: &ast.Self{}},
+		"declarations": &ast.Local{
+			Binds: ast.LocalBinds{
+				ast.LocalBind{
+					Variable: *newIdentifier("a"),
+					Body: &ast.Import{
+						File: &ast.LiteralString{
+							Kind:  ast.StringDouble,
+							Value: "a",
+						},
+					},
+				},
+			},
+			Body: &ast.Local{
+				Binds: ast.LocalBinds{
+					ast.LocalBind{
+						Variable: *newIdentifier("b"),
+						Body: &ast.LiteralString{
+							Kind:  ast.StringDouble,
+							Value: "b",
+						},
+					},
+				},
+				Body: &ast.Local{
+					Binds: ast.LocalBinds{
+						ast.LocalBind{
+							Variable: *newIdentifier("c"),
+							Body: &ast.Apply{
+								Target: &ast.Index{
+									Id: newIdentifier("new"),
+									Target: &ast.Var{
+										Id: *newIdentifier("deployment"),
+									},
+								},
+							},
+						},
+					},
+					Body: &ast.Object{},
+				},
+			},
+		},
+		"chained_apply": &ast.Apply{
+			Arguments: ast.Arguments{
+				Positional: ast.Nodes{
+					&ast.Var{Id: *newIdentifier("bar")},
+				},
+			},
+			Target: &ast.Index{
+				Id: newIdentifier("withBar"),
+				Target: &ast.Apply{
+					Arguments: ast.Arguments{
+						Positional: ast.Nodes{
+							&ast.Var{Id: *newIdentifier("foo")},
+						},
+					},
+					Target: &ast.Index{
+						Id: newIdentifier("withFoo"),
+						Target: &ast.Var{
+							Id: *newIdentifier("di"),
+						},
+					},
+				},
+			},
+		},
 
 		// errors
 		"unknown_node":           &noopNode{},
@@ -615,6 +680,27 @@ func Test_printer_err(t *testing.T) {
 
 	if len(p.output) != 0 {
 		t.Errorf("print() in error state should not add any output")
+	}
+}
+
+func Test_extractApply(t *testing.T) {
+	n := &ast.Apply{
+		Target: &ast.Index{
+			Id: newIdentifier("new"),
+			Target: &ast.Var{
+				Id: *newIdentifier("deployment"),
+			},
+		},
+	}
+
+	got, err := extractApply(n.Target)
+	if err != nil {
+		t.Fatalf("extractApply() returned unexpected error: %v", err)
+	}
+
+	expected := "deployment.new"
+	if got != expected {
+		t.Errorf("extractApply() = %s; expected = %s", got, expected)
 	}
 }
 

--- a/ksonnet-gen/printer/testdata/chained_apply
+++ b/ksonnet-gen/printer/testdata/chained_apply
@@ -1,0 +1,1 @@
+di.withFoo(foo).withBar(bar)

--- a/ksonnet-gen/printer/testdata/declarations
+++ b/ksonnet-gen/printer/testdata/declarations
@@ -1,0 +1,5 @@
+local a = import "a";
+local b = "b";
+local c = deployment.new();
+{
+}


### PR DESCRIPTION
Chained applies `a.b.c.d.e(arg1).f(arg2)` where not rendering correctly. This commit fixes that issue.

Also addresses the following smaller issues:
* introduces `NewInt` and `NewFloat` because the types are parsed slightly differently
* exports `ksonnet.FormatKind`. This functional is useful to consumers of the ksonnet lib.
 

Signed-off-by: bryanl <bryanliles@gmail.com>