### PR TITLE
ksonnet-lib bug fixes

### DIFF
--- a/ksonnet-gen/ksonnet/catalog.go
+++ b/ksonnet-gen/ksonnet/catalog.go
@@ -152,7 +152,7 @@ func (c *Catalog) Fields() ([]Field, error) {
 			return nil, errors.Wrapf(err, "parse description for %s", name)
 		}
 
-		// If there is a path, this should ot be a hidden object. This
+		// If there is a path, this should not be a hidden object. This
 		// makes this schema a field.
 		if _, ok := c.paths[name]; ok {
 			continue

--- a/ksonnet-gen/ksonnet/properties.go
+++ b/ksonnet-gen/ksonnet/properties.go
@@ -74,7 +74,7 @@ func isSkippedProperty(name string, schema spec.Schema) bool {
 		return true
 	}
 
-	if strings.Contains(strings.ToLower(schema.Description), "read-only") {
+	if strings.Contains(strings.ToLower(schema.Description), "read-only") && name != "readOnly" {
 		return true
 	}
 

--- a/ksonnet-gen/nodemaker/nodemaker_test.go
+++ b/ksonnet-gen/nodemaker/nodemaker_test.go
@@ -294,7 +294,9 @@ func TestObject(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			node, expected := tc.object(t)
 			if node != nil && expected != nil {
-				require.Equal(t, expected, node.Node())
+				if !assert.Equal(t, expected, node.Node()) {
+					printer.Fprint(os.Stdout, node.Node())
+				}
 			}
 		})
 	}
@@ -997,6 +999,10 @@ func kvFromMap1(t *testing.T) (Noder, ast.Node) {
 			"a": "a",
 			"b": 2,
 		},
+		"obj2": map[string]interface{}{
+			"a": "a",
+			"b": 2,
+		},
 		"array": []interface{}{"a", "b"},
 	}
 
@@ -1045,6 +1051,33 @@ func kvFromMap1(t *testing.T) (Noder, ast.Node) {
 					Kind: ast.ObjectFieldID,
 					Hide: ast.ObjectFieldInherit,
 					Id:   newIdentifier("obj"),
+					Expr2: &astext.Object{
+						Fields: astext.ObjectFields{
+							{
+								ObjectField: ast.ObjectField{
+									Kind:  ast.ObjectFieldID,
+									Hide:  ast.ObjectFieldInherit,
+									Id:    newIdentifier("a"),
+									Expr2: &ast.LiteralString{Value: "a", Kind: ast.StringDouble},
+								},
+							},
+							{
+								ObjectField: ast.ObjectField{
+									Kind:  ast.ObjectFieldID,
+									Hide:  ast.ObjectFieldInherit,
+									Id:    newIdentifier("b"),
+									Expr2: NewInt(2).Node(),
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				ObjectField: ast.ObjectField{
+					Kind: ast.ObjectFieldID,
+					Hide: ast.ObjectFieldInherit,
+					Id:   newIdentifier("obj2"),
 					Expr2: &astext.Object{
 						Fields: astext.ObjectFields{
 							{


### PR DESCRIPTION
Fixes:
* nodemaker kv maps did not handle `map[string]interface{}`
* catalog property filtering filtered out properties named, `readOnly`.