### PR TITLE
Print index names which require quotes

### DIFF
--- a/ksonnet-gen/printer/printer.go
+++ b/ksonnet-gen/printer/printer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -547,6 +548,8 @@ func (p *printer) addMethodSignature(method *ast.Function) {
 	p.writeString(")")
 }
 
+var reDotIndex = regexp.MustCompile(`^\w[A-Za-z0-9]*$`)
+
 func indexID(i *ast.Index) (string, error) {
 	if i == nil {
 		return "", errors.New("index is nil")
@@ -560,12 +563,22 @@ func indexID(i *ast.Index) (string, error) {
 			if t == nil {
 				return "", errors.New("string id is nil")
 			}
-			return fmt.Sprintf(".%s", t.Value), nil
+
+			id := t.Value
+			if reDotIndex.MatchString(id) {
+				return fmt.Sprintf(".%s", id), nil
+			}
+			return fmt.Sprintf(`["%s"]`, id), nil
 		case *ast.Var:
 			return fmt.Sprintf("[%s]", string(t.Id)), nil
 		}
 	} else if i.Id != nil {
-		return fmt.Sprintf(".%s", string(*i.Id)), nil
+		id := string(*i.Id)
+		if reDotIndex.MatchString(id) {
+			return fmt.Sprintf(".%s", id), nil
+		}
+		return fmt.Sprintf(`["%s"]`, id), nil
+
 	} else {
 		return "", errors.New("index and id can't both be blank")
 	}

--- a/ksonnet-gen/printer/printer_test.go
+++ b/ksonnet-gen/printer/printer_test.go
@@ -41,6 +41,8 @@ func TestFprintf(t *testing.T) {
 		{name: "conditional_no_false"},
 		{name: "index"},
 		{name: "index_with_index"},
+		{name: "index_quote_name"},
+		{name: "index_quote_name_2"},
 		{name: "array"},
 		{name: "self_apply"},
 		{name: "apply_with_multiple_arguments"},
@@ -177,6 +179,48 @@ var (
 						},
 					},
 				},
+			},
+		},
+		"index_quote_name": &ast.Object{
+			Fields: ast.ObjectFields{
+				{
+					Kind: ast.ObjectFieldID,
+					Id:   &id1,
+					Expr2: &ast.Index{
+						Id: newIdentifier("baz-dashed"),
+						Target: &ast.Index{
+							Id: newIdentifier("bar-dashed"),
+							Target: &ast.Var{
+								Id: *newIdentifier("foo"),
+							},
+						},
+					},
+				},
+			},
+		},
+		"index_quote_name_2": &ast.Index{
+			Target: &ast.Index{
+				Target: &ast.Apply{
+					Target: &ast.Index{
+						Target: &ast.Var{
+							Id: *newIdentifier("std"),
+						},
+						Id: newIdentifier("extVar"),
+					},
+					Arguments: ast.Arguments{
+						Positional: ast.Nodes{
+							&ast.LiteralString{
+								Value: "__ksonnet/params",
+								Kind:  ast.StringDouble,
+							},
+						},
+					},
+				},
+				Id: newIdentifier("components"),
+			},
+			Index: &ast.LiteralString{
+				Value: "my-service",
+				Kind:  ast.StringDouble,
 			},
 		},
 		"object_mixin": &ast.Object{

--- a/ksonnet-gen/printer/testdata/index_quote_name
+++ b/ksonnet-gen/printer/testdata/index_quote_name
@@ -1,0 +1,3 @@
+{
+  foo:: foo["bar-dashed"]["baz-dashed"],
+}

--- a/ksonnet-gen/printer/testdata/index_quote_name_2
+++ b/ksonnet-gen/printer/testdata/index_quote_name_2
@@ -1,0 +1,1 @@
+std.extVar("__ksonnet/params").components["my-service"]


### PR DESCRIPTION
Index: `foo.dashed-bar.baz` is incorrect. Should be
`foo["dashed-bar"].baz`

Signed-off-by: bryanl <bryanliles@gmail.com>