### PR TITLE
Generate ctor body for mixinInstance function

### DIFF
--- a/ksonnet-gen/ksonnet/constructors.go
+++ b/ksonnet-gen/ksonnet/constructors.go
@@ -12,7 +12,7 @@ import (
 var (
 	// reCtorSetter is a regex that matches function names. It'll successfully
 	// match `withName`, `foo.withName`, and `foo.bar.withName`.
-	reCtorSetter = regexp.MustCompile(`((^.*?)\.)*(with\w+)$`)
+	reCtorSetter = regexp.MustCompile(`((^.*?)\.)*(with\w+|mixinInstance)$`)
 )
 
 func matchCtorSetter(in string) (string, string, error) {


### PR DESCRIPTION
A constructor with a reference to a mixinInstance function would previously silently fail to generate the code in the constructor body.

The only affected constructor is `volume.fromEmptyDir`:
```
<           fromEmptyDir(name="", emptyDir={}):: self.withName(name),
---
>           fromEmptyDir(name="", emptyDir={}):: self.withName(name) + self.mixin.emptyDir.mixinInstance(emptyDir),
```