### PR TITLE
Support underscores in field names.

### DIFF
--- a/ksonnet-gen/astext/astext.go
+++ b/ksonnet-gen/astext/astext.go
@@ -34,9 +34,9 @@ type Object struct {
 
 var (
 	// reFieldStr matches a field id that should be enclosed in quotes.
-	reFieldStr = regexp.MustCompile(`^[A-Za-z]+[A-Za-z0-9\-]*$`)
+	reFieldStr = regexp.MustCompile(`^[_A-Za-z]+[_A-Za-z0-9\-]*$`)
 	// reField matches a field id.
-	reField = regexp.MustCompile(`^[A-Za-z]+[A-Za-z0-9]*$`)
+	reField = regexp.MustCompile(`^[_A-Za-z]+[_A-Za-z0-9]*$`)
 )
 
 // CreateField creates an ObjectField with a name. If the name matches `reFieldStr`, it will

--- a/ksonnet-gen/astext/astext_test.go
+++ b/ksonnet-gen/astext/astext_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestCreateField(t *testing.T) {
 	id := ast.Identifier("name")
+	uId := ast.Identifier("underscore_name")
 
 	cases := []struct {
 		name     string
@@ -20,6 +21,21 @@ func TestCreateField(t *testing.T) {
 			expected: &ObjectField{
 				ObjectField: ast.ObjectField{
 					Kind: ast.ObjectFieldID, Id: &id}},
+		},
+		{
+			name: "underscore_name",
+			expected: &ObjectField{
+				ObjectField: ast.ObjectField{
+					Kind: ast.ObjectFieldID, Id: &uId}},
+		},
+		{
+			name: "underscore_field-",
+			expected: &ObjectField{
+				ObjectField: ast.ObjectField{
+					Kind: ast.ObjectFieldStr, Expr1: &ast.LiteralString{
+						Value: "underscore_field-",
+						Kind:  ast.StringDouble,
+					}}},
 		},
 		{
 			name: "dashed-name",


### PR DESCRIPTION
* Field names with underscores are causing errors "invalid field name" (see ksonnet/ksonnet#504 and ksonnet/ksonnet#554).

* According to the jsonnet spec (https://jsonnet.org/ref/spec.html) underscores should be allowed in ids.

* But the regexes in astext.go are missing underscores.

Fix ksonnet/ksonnet#504 and ksonnet/ksonnet#554