### PR TITLE
Unescape strings with newlines and tabs

### DIFF
--- a/ksonnet-gen/printer/printer.go
+++ b/ksonnet-gen/printer/printer.go
@@ -152,10 +152,6 @@ func detectQuoteMode(s string, kind ast.LiteralStringKind) quoteMode {
 	default:
 		return quoteModeNone
 	case ast.StringSingle:
-		if strings.ContainsAny(s, "\n") {
-			return quoteModeDouble
-		}
-
 		// Go with single unless there's only single quotes already.
 		useSingle := !(hasSingle && !hasDouble)
 		if useSingle {
@@ -163,10 +159,6 @@ func detectQuoteMode(s string, kind ast.LiteralStringKind) quoteMode {
 		}
 
 	case ast.StringDouble:
-		if strings.ContainsAny(s, "\n") {
-			return quoteModeDouble
-		}
-
 		// Cases:
 		// 1. [" 'abc' "] -> [" 'abc' "]
 		// 2. [" \"abc\" "] -> [' "abc" ']

--- a/ksonnet-gen/printer/printer.go
+++ b/ksonnet-gen/printer/printer.go
@@ -152,6 +152,10 @@ func detectQuoteMode(s string, kind ast.LiteralStringKind) quoteMode {
 	default:
 		return quoteModeNone
 	case ast.StringSingle:
+		if strings.ContainsAny(s, "\n") {
+			return quoteModeDouble
+		}
+
 		// Go with single unless there's only single quotes already.
 		useSingle := !(hasSingle && !hasDouble)
 		if useSingle {
@@ -159,6 +163,10 @@ func detectQuoteMode(s string, kind ast.LiteralStringKind) quoteMode {
 		}
 
 	case ast.StringDouble:
+		if strings.ContainsAny(s, "\n") {
+			return quoteModeDouble
+		}
+
 		// Cases:
 		// 1. [" 'abc' "] -> [" 'abc' "]
 		// 2. [" \"abc\" "] -> [' "abc" ']
@@ -192,7 +200,7 @@ func stringQuote(s string, useSingle bool) string {
 	sb := strings.Builder{}
 	sb.WriteByte(singleQuote)
 	flipped := strings.Replace(quoted[1:len(quoted)-1], "'", "\\'", -1)
-	flipped = strings.Replace(quoted[1:len(quoted)-1], "\\\"", "\"", -1) // TODO use Replacer
+	flipped = strings.Replace(flipped, "\\\"", "\"", -1) // TODO use Replacer
 	sb.WriteString(flipped)
 	sb.WriteByte(singleQuote)
 
@@ -428,7 +436,13 @@ func (p *printer) print(n interface{}) {
 			return
 		case ast.StringSingle, ast.StringDouble:
 			useSingle := (qm != quoteModeDouble)
-			quoted := stringQuote(t.Value, useSingle)
+
+			// Unescape newlines and tabs. The jsonnet parser will escape
+			// these during parsing.
+			val := strings.Replace(t.Value, "\\n", "\n", -1)
+			val = strings.Replace(val, "\\t", "\t", -1)
+
+			quoted := stringQuote(val, useSingle)
 			p.writeString(quoted)
 		case ast.StringBlock:
 			p.writeString("|||")

--- a/ksonnet-gen/printer/testdata/literal_with_newline
+++ b/ksonnet-gen/printer/testdata/literal_with_newline
@@ -1,3 +1,3 @@
 {
-  foo: "value1\nvalue2",
+  foo: 'value1\nvalue2',
 }

--- a/ksonnet-gen/printer/testdata/literal_with_newline
+++ b/ksonnet-gen/printer/testdata/literal_with_newline
@@ -1,3 +1,3 @@
 {
-  foo: 'value1\nvalue2',
+  foo: "value1\nvalue2",
 }


### PR DESCRIPTION
* If LiteralString value contains escaped newlines or tabs, unescape them

Re: https://github.com/ksonnet/ksonnet/issues/670

Signed-off-by: bryanl <bryanliles@gmail.com>